### PR TITLE
Added Standard Table Symbols to application.json and requests.js.

### DIFF
--- a/application.json
+++ b/application.json
@@ -83,6 +83,15 @@
                 }
             }, {
                 "id": {
+                    "en": "Symbol",
+                    "fr": "Symbol"
+                },
+                "label": {
+                    "en": "Symbol",
+                    "fr": "Symbole"
+                }                
+            }, {
+                "id": {
                     "en": "NullDescription_EN",
                     "fr": "NullDescription_FR"
                 },

--- a/tools/requests.js
+++ b/tools/requests.js
@@ -302,8 +302,11 @@ export default class Requests {
 			var unit = f.attributes[`UOM_${locale}`];
 			var value = f.attributes[`FormattedValue_${locale}`];
 			var html = f.attributes[`IndicatorDisplay_${locale}`];
+			var value_symbol = (f.attributes[`Symbol`] && value != "F") ? f.attributes[`Symbol`] : ''; /* prevents F from displaying twice */
+			var value_symbol_foot = f.attributes[`Symbol`] || ''; 
+			var symbol_desc = f.attributes[`NullDescription_${locale}`] || '';
 			
-			var content = `<b>${unit}</b>: ${value}<br><br>${html}`;
+			var content = `<b>${unit}</b>: ${value} <sup>${value_symbol}</sup><br><br>${html}<br><sup>${value_symbol_foot}</sup> ${symbol_desc}`;
 			
 			d.Resolve({ feature:f, geometry:geometry, content:content, title:title });
 		}, error => d.Reject(error));


### PR DESCRIPTION
STS are being returned from the database but were not being displayed in the popup or the table. Added STS to application.json table headers so it displays in the table and updated requests.js to show the symbol and description in the popup. 