### PR TITLE
Restores ESRI default map cursor.

### DIFF
--- a/application.css
+++ b/application.css
@@ -302,10 +302,6 @@
 	height:100%;
 }
 
-.gexp .map-container .esri-view .esri-view-surface {
-	cursor : pointer;
-}
-
 /* Map Styler widget */
 .gexp .basemap { 
     width: 300px;


### PR DESCRIPTION
11.h - Show hand icon while panning the map 
Application.css was overriding default cursor and preventing grabbing hand from displaying when user pans. After discusssion - Restored to default ESRI cursor.